### PR TITLE
Persist Menu Item Selection between runs 

### DIFF
--- a/Occcam News/App/RootContentView.swift
+++ b/Occcam News/App/RootContentView.swift
@@ -10,11 +10,12 @@ import SwiftUI
 struct RootContentView: View {
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @StateObject var bookmarks = ArticleBookmarkObservable(PlistStore("bookmarks"))
+    @AppStorage("menu_item_selection") var selectedMenuItem: MenuItem.ID?
     private let repository = NewsRepository()
     var body: some View {
         switch horizontalSizeClass {
         case .regular:
-            SideBarContentView {
+            SideBarContentView(selectedMenuItem: $selectedMenuItem) {
                 switch $0 {
                 case .search:
                     searchView
@@ -36,7 +37,7 @@ struct RootContentView: View {
 }
 
 private extension RootContentView {
-    private func topHeadlinesView(_ category: NewsCategory = .general) -> some View {
+    private func topHeadlinesView(_ category: NewsCategory) -> some View {
         return NewsTabView(observable:
             ArticleListViewObservable(repository: repository, category: category)
         )
@@ -59,9 +60,18 @@ private extension RootContentView {
 private extension RootContentView {
     private var headlinesTab: some View {
         return NavigationView {
-            topHeadlinesView()
+            topHeadlinesView(currentCategory)
         }
         .tabItem { Label("News", systemImage: "newspaper") }
+    }
+
+    private var currentCategory: NewsCategory {
+        switch MenuItem(selectedMenuItem) {
+        case let .category(category):
+            return category
+        default:
+            return .general
+        }
     }
 
     private var searchTab: some View {

--- a/Occcam News/App/SideBarContentView.swift
+++ b/Occcam News/App/SideBarContentView.swift
@@ -8,9 +8,7 @@
 import SwiftUI
 
 struct SideBarContentView<DetailContent: View>: View {
-    private let detailContent: (MenuItem) -> DetailContent
-
-    @AppStorage("menu_item_selection") var selectedMenuItem: MenuItem.ID?
+    @Binding var selectedMenuItem: MenuItem.ID?
     private var selection: Binding<MenuItem.ID?> {
         Binding {
             selectedMenuItem ?? MenuItem.category(.general).id
@@ -22,9 +20,7 @@ struct SideBarContentView<DetailContent: View>: View {
 
     }
 
-    init(@ViewBuilder detailContent: @escaping (MenuItem) -> DetailContent) {
-        self.detailContent = detailContent
-    }
+    @ViewBuilder let detailContent: (MenuItem) -> DetailContent
 
     var body: some View {
         if #available(iOS 16.0, *) {
@@ -54,7 +50,7 @@ struct SideBarContentView<DetailContent: View>: View {
 
 struct SideBarContentView_Previews: PreviewProvider {
     static var previews: some View {
-        SideBarContentView { item in
+        SideBarContentView(selectedMenuItem: .constant(nil)) { item in
             switch item {
             case .search:
                 Color.red

--- a/Occcam News/App/TabContentView.swift
+++ b/Occcam News/App/TabContentView.swift
@@ -24,8 +24,10 @@ struct TabContentView<Content: View>: View {
 struct TabContentView_Previews: PreviewProvider {
     static var previews: some View {
         TabContentView {
-            Color.indigo
-            Color.cyan
+            ForEach([Color.red, .green, .blue], id: \.self) { color in
+                color
+                    .tabItem { Label(String(describing: color), systemImage: "") }
+            }
         }
     }
 }

--- a/Occcam News/Features/TopHeadlines/Observables/ArticleListViewObservable.swift
+++ b/Occcam News/Features/TopHeadlines/Observables/ArticleListViewObservable.swift
@@ -11,8 +11,14 @@ class ArticleListViewObservable: ObservableObject, LoadableObject {
 
     private let repository: TopHeadlinesRepository
     @Published private(set) var phase: LoadingState<[Article]>
-    @Published var selectedCategory: NewsCategory
-
+    @Published var selectedCategory: NewsCategory {
+        didSet {
+            if oldValue != selectedCategory {
+                selectedMenuItem = MenuItem.category(selectedCategory).id
+            }
+        }
+    }
+    @AppStorage("menu_item_selection") private var selectedMenuItem: MenuItem.ID?
     internal init(repository: TopHeadlinesRepository,
                   phase: LoadingState<[Article]> = .idle,
                   category: NewsCategory = .general) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Persist `MenuItem` for both compact & regular horizontal size classes
- Update `TabContentView` preview

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The category selected by the user should persist when the app is closed

## Types of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring 
- [ ] Documentation Update
- [ ] Other (please describe):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
