### PR TITLE
Back porting ContentUnavailableView

### DIFF
--- a/Occcam News.xcodeproj/project.pbxproj
+++ b/Occcam News.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		BAA281FA2B33361B006E4DA6 /* MenuItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAA281F92B33361B006E4DA6 /* MenuItemView.swift */; };
 		BAA2B721293FF5F000FB0034 /* Swifter in Frameworks */ = {isa = PBXBuildFile; productRef = BAA2B720293FF5F000FB0034 /* Swifter */; };
 		BAA3ACED29C5320F00033620 /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = BAA3ACEC29C5320E00033620 /* Config.xcconfig */; };
+		BAB15ED52B4DF4E000B5CCEF /* BPContentUnavailableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB15ED42B4DF4E000B5CCEF /* BPContentUnavailableView.swift */; };
 		BAF1D4DC2A93DE0000C93976 /* Poppify in Frameworks */ = {isa = PBXBuildFile; productRef = BAF1D4DB2A93DE0000C93976 /* Poppify */; };
 /* End PBXBuildFile section */
 
@@ -131,6 +132,7 @@
 		BAA281F72B325859006E4DA6 /* MenuItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuItem.swift; sourceTree = "<group>"; };
 		BAA281F92B33361B006E4DA6 /* MenuItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuItemView.swift; sourceTree = "<group>"; };
 		BAA3ACEC29C5320E00033620 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
+		BAB15ED42B4DF4E000B5CCEF /* BPContentUnavailableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BPContentUnavailableView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -412,6 +414,7 @@
 				BAA281F22B308C77006E4DA6 /* NewsCategorySelectionView.swift */,
 				BAA281F42B308D44006E4DA6 /* NavigationItemsView.swift */,
 				BAA281F92B33361B006E4DA6 /* MenuItemView.swift */,
+				BAB15ED42B4DF4E000B5CCEF /* BPContentUnavailableView.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -708,6 +711,7 @@
 				BA86B7942B0BDA1B001DD073 /* LoadingState.swift in Sources */,
 				BA504FEA2B14F88B00865F6E /* BookmarkTabView.swift in Sources */,
 				BA86B7992B0D3E9F001DD073 /* ContentErrorView.swift in Sources */,
+				BAB15ED52B4DF4E000B5CCEF /* BPContentUnavailableView.swift in Sources */,
 				BA86B77C2B0811D6001DD073 /* NewsCategory.swift in Sources */,
 				BA5050022B1F561900865F6E /* TabContentView.swift in Sources */,
 				BA86B7742B064B81001DD073 /* SafariView.swift in Sources */,

--- a/Occcam News/Shared/DesignSystem/Components/AsyncContentView.swift
+++ b/Occcam News/Shared/DesignSystem/Components/AsyncContentView.swift
@@ -13,10 +13,8 @@ protocol LoadableObject: ObservableObject {
     func load()
 }
 
-struct AsyncContentView<Source: LoadableObject,
-                            LoadingView: View,
-                            Idle: View,
-                            Content: View>: View {
+struct AsyncContentView<Source, LoadingView, Idle, Content>: View
+    where Source: LoadableObject, LoadingView: View, Idle: View, Content: View {
     @ObservedObject var source: Source
     var loadingView: LoadingView
     var idle: Idle

--- a/Occcam News/Shared/DesignSystem/Components/BPContentUnavailableView.swift
+++ b/Occcam News/Shared/DesignSystem/Components/BPContentUnavailableView.swift
@@ -1,0 +1,168 @@
+//
+//  BPContentUnavailableView.swift
+//  Occcam News
+//
+//  Created by Brian Munjoma on 09/01/2024.
+//
+
+import SwiftUI
+
+@available(iOS, deprecated: 17.0, message: "Use SwiftUI's ContentUnavailableView API beyond iOS 16")
+public struct ContentUnavailableView<Label, Description, Actions>: View
+    where Label: View, Description: View, Actions: View {
+
+    private let label: Label
+    private let description: Description
+    private let actions: Actions
+    /// Creates an interface, consisting of a label and additional content, that you
+    /// display when the content of your app is unavailable to users.
+    ///
+    /// - Parameters:
+    ///   - label: The label that describes the view.
+    ///   - description: The view that describes the interface.
+    ///   - actions: The content of the interface actions.
+    public init(@ViewBuilder label: () -> Label,
+                @ViewBuilder description: () -> Description = { EmptyView() },
+                @ViewBuilder actions: () -> Actions = { EmptyView() }) {
+        self.label = label()
+        self.description = description()
+        self.actions = actions()
+    }
+
+    /// The content and behavior of the view.
+    ///
+    /// When you implement a custom view, you must implement a computed
+    /// `body` property to provide the content for your view. Return a view
+    /// that's composed of built-in views that SwiftUI provides, plus other
+    /// composite views that you've already defined:
+    ///
+    ///     struct MyView: View {
+    ///         var body: some View {
+    ///             Text("Hello, World!")
+    ///         }
+    ///     }
+    ///
+    /// For more information about composing views and a view hierarchy,
+    /// see <doc:Declaring-a-Custom-View>.
+    @MainActor public var body: some View {
+        VStack(spacing: 15) {
+            VStack(spacing: 8) {
+                label
+                    .labelStyle(AdaptiveLabelStyle())
+                description
+                    .font(.subheadline)
+                    .foregroundColor(.gray)
+            }
+            actions
+        }
+        .padding(.horizontal)
+    }
+}
+
+struct AdaptiveLabelStyle: LabelStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        VStack(spacing: 10) {
+            configuration.icon
+                .imageScale(.large)
+                .scaleEffect(3.0, anchor: .bottom)
+                .foregroundStyle(Color.gray)
+            configuration.title
+                .font(.title2.weight(.bold))
+        }
+        .padding(.horizontal)
+    }
+}
+
+typealias DefaultLabel = Label<Text, Image>
+extension ContentUnavailableView where Label == DefaultLabel, Description == Text?, Actions == EmptyView {
+
+    /// Creates an interface, consisting of a title generated from a localized
+    /// string, an image and additional content, that you display when the
+    /// content of your app is unavailable to users.
+    ///
+    /// - Parameters:
+    ///    - title: A title generated from a localized string.
+    ///    - image: The name of the image resource to lookup.
+    ///    - description: The view that describes the interface.
+    init(_ title: LocalizedStringKey, image name: String, description: Text? = nil) {
+        self.init {
+            Label(title, image: name)
+        } description: {
+            description
+        }
+    }
+
+    /// Creates an interface, consisting of a title generated from a localized
+    /// string, a system icon image and additional content, that you display when the
+    /// content of your app is unavailable to users.
+    ///
+    /// - Parameters:
+    ///    - title: A title generated from a localized string.
+    ///    - systemImage: The name of the system symbol image resource to lookup.
+    ///      Use the SF Symbols app to look up the names of system symbol images.
+    ///    - description: The view that describes the interface.
+    init(_ title: LocalizedStringKey, systemImage name: String, description: Text? = nil) {
+        self.init {
+            Label(title, systemImage: name)
+        } description: {
+            description
+        }
+    }
+
+    /// Creates an interface, consisting of a title generated from a string,
+    /// an image and additional content, that you display when the content of
+    /// your app is unavailable to users.
+    ///
+    /// - Parameters:
+    ///    - title: A string used as the title.
+    ///    - image: The name of the image resource to lookup.
+    ///    - description: The view that describes the interface.
+    init<S>(_ title: S, image name: String, description: Text? = nil) where S: StringProtocol {
+        self.init {
+            Label(title, image: name)
+        } description: {
+            description
+        }
+    }
+
+    /// Creates an interface, consisting of a title generated from a string,
+    /// a system icon image and additional content, that you display when the
+    /// content of your app is unavailable to users.
+    ///
+    /// - Parameters:
+    ///    - title: A string used as the title.
+    ///    - systemImage: The name of the system symbol image resource to lookup.
+    ///      Use the SF Symbols app to look up the names of system symbol images.
+    ///    - description: The view that describes the interface.
+    init<S>(_ title: S, systemImage name: String, description: Text? = nil) where S: StringProtocol {
+        self.init {
+            Label(title, systemImage: name)
+        } description: {
+            description
+        }
+    }
+}
+
+struct ContentUnavailableView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentUnavailableView("Some",
+                               systemImage: "globe")
+        .previewDisplayName("Label")
+
+        ContentUnavailableView("Some",
+                               systemImage: "globe",
+                               description: Text("Check your internet connection"))
+        .previewDisplayName("Label w/ Description")
+
+        ContentUnavailableView {
+            Label("Empty Bookmarks", systemImage: "bookmark")
+        } description: {
+            Text("Explore a great movie and bookmark the one you love to enjoy later.")
+        } actions: {
+            // 2
+            Button("Browse Movies") {}
+            .buttonStyle(.borderedProminent)
+        }
+        .previewDisplayName("Label w/ Description + Action")
+    }
+}

--- a/Occcam News/Shared/DesignSystem/Components/BPContentUnavailableView.swift
+++ b/Occcam News/Shared/DesignSystem/Components/BPContentUnavailableView.swift
@@ -8,6 +8,10 @@
 import SwiftUI
 
 @available(iOS, deprecated: 17.0, message: "Use SwiftUI's ContentUnavailableView API beyond iOS 16")
+@available(macOS, deprecated: 14.0, message: "Use SwiftUI's ContentUnavailableView API beyond macOS 13")
+@available(macCatalyst, deprecated: 17.0, message: "Use SwiftUI's ContentUnavailableView API beyond Mac Catalyst 16")
+@available(tvOS, deprecated: 17.0, message: "Use SwiftUI's ContentUnavailableView API beyond tvOS 16")
+@available(watchOS, deprecated: 10.0, message: "Use SwiftUI's ContentUnavailableView API beyond watchOS 9")
 public struct ContentUnavailableView<Label, Description, Actions>: View
     where Label: View, Description: View, Actions: View {
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- Created `ContentUnavailableView` using Apple's specification & documentation
- Implemented view body
- Added deprecation message for all applicable platforms
- Updated style of `AsyncContentView` to better match `ContentUnavailableView`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`ContentUnavailableView` is only available in on certain platforms, so I attempted to back port it 

## Types of change
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring 
- [ ] Documentation Update
- [ ] Other (please describe):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
